### PR TITLE
Remove Deno formatter check from CI

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -61,8 +61,6 @@ jobs:
             exit 1
           fi
 
-      - run: deno fmt --check
-
       - run: deno lint
 
       - name: Validate JSR package version with NPM package version


### PR DESCRIPTION
## Summary

- remove `deno fmt --check` from the regular Deno CI workflow
- keep Deno CI focused on Deno compatibility checks: install, package export import, lint, dependency/version checks, and clean working-tree handling

## Context

Repo source formatting is Prettier-owned. Deno formatting can disagree with Prettier on TypeScript source, so asserting `deno fmt --check` in regular CI makes the Deno and Node formatter checks fight.

JSR release formatting should be handled separately in the release/tag flow so published source still matches a clean release tag.

## Validation

- `yarn`
- `yarn format && yarn lint --fix && yarn build && yarn flow && yarn test`